### PR TITLE
Made stream delete itself after ending

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -413,8 +413,9 @@ class Connection extends Protocol {
 
   }
 
-  deleteStream() {
-
+  deleteStream(server) {
+    delete server.producers[this.streamName]
+    this.stop()
   }
 
   pauseOrUnpauseStream() {

--- a/server.js
+++ b/server.js
@@ -135,7 +135,7 @@ class RTMPServer extends tcp.Server {
         client.closeStream();
         break;
       case 'deleteStream':
-        client.deleteStream();
+        client.deleteStream(this);
         break;
       case 'pause':
         client.pauseOrUnpauseStream();


### PR DESCRIPTION
This gets the stream to delete itself after ending and allows the stream name to be used again. I ran into the issue of it still registering as there, even after closing the stream, so I did this.